### PR TITLE
Always use synchronous XHR, when using polyfill

### DIFF
--- a/sendbeacon.js
+++ b/sendbeacon.js
@@ -15,10 +15,9 @@ function polyfill () {
 
 function sendBeacon (url, data) {
   const event = this.event && this.event.type
-  const sync = event === 'unload' || event === 'beforeunload'
 
   const xhr = ('XMLHttpRequest' in this) ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP')
-  xhr.open('POST', url, !sync)
+  xhr.open('POST', url, false)
   xhr.withCredentials = true
   xhr.setRequestHeader('Accept', '*/*')
 


### PR DESCRIPTION
>For browsers that don't support navigator.sendBeacon,
which means they are really old,
I'd rather always use synchronous XHR.
Also, in 2020, I am using the page visibility api instead of unload/beforeunload events

Merging to master of my fork